### PR TITLE
Switches appsettings file names to lowercase so configuration loads on case-sensitive filesystems

### DIFF
--- a/src/Lumina.Infrastructure/Common/DependencyInjection/SharedConfiguration.cs
+++ b/src/Lumina.Infrastructure/Common/DependencyInjection/SharedConfiguration.cs
@@ -31,7 +31,7 @@ public static class SharedConfiguration
             throw new DirectoryNotFoundException($"The base path '{basePath}' does not exist.");
         configuration.SetBasePath(basePath);
         configuration.AddJsonFile("appsettings.shared.json", optional: false, reloadOnChange: true);
-        configuration.AddJsonFile("appsettings.shared.Development.json", optional: true, reloadOnChange: true);
+        configuration.AddJsonFile("appsettings.shared.development.json", optional: true, reloadOnChange: true);
         configuration.AddEnvironmentVariables(); // environment variables should override the configuration files
 
         // bind the appsettings sections

--- a/src/Lumina.Presentation.Api/Common/DependencyInjection/PresentationApiLayerConfiguration.cs
+++ b/src/Lumina.Presentation.Api/Common/DependencyInjection/PresentationApiLayerConfiguration.cs
@@ -28,7 +28,7 @@ internal static class PresentationApiLayerConfiguration
             throw new DirectoryNotFoundException($"The base path '{basePath}' does not exist.");
         configuration.SetBasePath(basePath);
         configuration.AddJsonFile("appsettings.json", optional: false, reloadOnChange: true);
-        configuration.AddJsonFile("appsettings.Development.json", optional: true, reloadOnChange: true);
+        configuration.AddJsonFile("appsettings.development.json", optional: true, reloadOnChange: true);
 
         return services;
     }

--- a/src/Lumina.Presentation.Web/Common/DependencyInjection/PresentationWebLayerConfiguration.cs
+++ b/src/Lumina.Presentation.Web/Common/DependencyInjection/PresentationWebLayerConfiguration.cs
@@ -24,7 +24,7 @@ internal static class PresentationWebLayerConfiguration
     {
         // add the configuration sources to the configuration builder
         configuration.AddJsonFile("appsettings.json", optional: false, reloadOnChange: true);
-        configuration.AddJsonFile("appsettings.Development.json", optional: true, reloadOnChange: true);
+        configuration.AddJsonFile("appsettings.development.json", optional: true, reloadOnChange: true);
         
         serviceCollection.AddOptions<ServerConfigurationModel>()
                          .Bind(configuration.GetRequiredSection(ServerConfigurationModel.SECTION_NAME))


### PR DESCRIPTION
The Windows VM running on KVM/QEMU has a filesystem component located on a drive with an EXT4 filesystem, which is case-sensitive. The appsettings environment files exist on disk as appsettings.development.json and appsettings.shared.development.json, but the configuration loaders referenced the PascalCase names (appsettings.Development.json and appsettings.shared.Development.json). While this mismatch is harmless on a case-insensitive Windows filesystem, on EXT4 the files were never matched, so Visual Studio threw an exception for a configuration value that was missing from the loaded settings.

Updates the configuration loaders in the API, Web, and shared infrastructure projects to reference the lowercase file names, matching what exists on disk.