### PR TITLE
Switches integration tests to per-factory shared in-memory SQLite databases

### DIFF
--- a/tests/IntegrationTests/Lumina.Presentation.Api.IntegrationTests/Common/Setup/LuminaApiFactory.cs
+++ b/tests/IntegrationTests/Lumina.Presentation.Api.IntegrationTests/Common/Setup/LuminaApiFactory.cs
@@ -26,7 +26,9 @@ namespace Lumina.Presentation.Api.IntegrationTests.Common.Setup;
 public class LuminaApiFactory : WebApplicationFactory<Program>, IDisposable
 {
     private readonly SqliteConnection _connection;
+    private readonly string _sharedInMemoryConnectionString;
     private const string TEST_ENCRYPTION_KEY = "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=";
+    private const string SHARED_IN_MEMORY_CONNECTION_STRING_PREFIX = "Data Source=lumina-tests-{0};Mode=Memory;Cache=Shared";
     private static byte s_IpClass = 25;
 
     public static byte IpClass => s_IpClass++;
@@ -36,7 +38,12 @@ public class LuminaApiFactory : WebApplicationFactory<Program>, IDisposable
     /// </summary>
     public LuminaApiFactory()
     {
-        _connection = new SqliteConnection("DataSource=:memory:");
+        // each factory gets its own uniquely named shared in-memory database, so that parallel test classes remain isolated from one another;
+        // the shared cache allows each DbContext to open its own pooled connection to the same database, instead of sharing a single connection,
+        // which would otherwise serialize every request on one connection and cause nested transaction errors between requests
+        _sharedInMemoryConnectionString = string.Format(SHARED_IN_MEMORY_CONNECTION_STRING_PREFIX, Guid.NewGuid());
+        // keep a single anchor connection open, so that the shared in-memory database it refers to is not dropped
+        _connection = new SqliteConnection(_sharedInMemoryConnectionString);
         _connection.Open();
     }
 
@@ -73,7 +80,7 @@ public class LuminaApiFactory : WebApplicationFactory<Program>, IDisposable
             // add SQLite DbContext configuration
             services.AddDbContext<LuminaDbContext>((serviceProvider, options) =>
             {
-                options.UseSqlite(_connection);
+                options.UseSqlite(_sharedInMemoryConnectionString);
                 options.AddInterceptors(serviceProvider.GetRequiredService<UpdateAuditableEntitiesInterceptor>());
             });
             // configure JWT authentication for testing


### PR DESCRIPTION
Instead of sharing a single SQLite connection across all DbContexts within a factory, each factory now opens its own uniquely named shared in-memory database, so that every DbContext gets its own pooled connection. This prevents nested transaction errors caused by a cancelled request leaving a transaction open on the shared connection, since the connection is no longer reused across DbContexts, and keeps parallel test classes isolated from one another.