### PR TITLE
Increases the SQLite busy timeout to 30 seconds

### DIFF
--- a/src/Lumina.Presentation.Api/Program.cs
+++ b/src/Lumina.Presentation.Api/Program.cs
@@ -93,7 +93,7 @@ public class Program
                 SqliteConnection sqliteConnection = new(context.Database.GetDbConnection().ConnectionString);
                 sqliteConnection.Open();
                 using SqliteCommand sqliteCommand = sqliteConnection.CreateCommand();
-                sqliteCommand.CommandText = "PRAGMA journal_mode=WAL; PRAGMA busy_timeout=10000;";
+                sqliteCommand.CommandText = "PRAGMA journal_mode=WAL; PRAGMA busy_timeout=30000;";
                 sqliteCommand.ExecuteNonQuery();
                 sqliteConnection.Close();
             }


### PR DESCRIPTION
Raises the busy timeout used when opening the SQLite connection from 10 to 30 seconds, so that the Entity Framework connection and the dedicated connections used by the bulk data access operations of Dapper keep retrying for longer instead of failing with database locking errors during concurrent access.